### PR TITLE
ARC conversion

### DIFF
--- a/PDKeychainBindingsController.xcodeproj/project.pbxproj
+++ b/PDKeychainBindingsController.xcodeproj/project.pbxproj
@@ -611,6 +611,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_ENABLE_OBJC_ARC = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -628,6 +629,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_ENABLE_OBJC_ARC = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_VERSION = com.apple.compilers.llvmgcc42;
@@ -643,7 +645,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_ARC = YES;
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -664,7 +667,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_ARC = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -684,7 +688,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/PDKeychainBindingsControllerOSXExample.app/Contents/MacOS/PDKeychainBindingsControllerOSXExample";
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = "$(DEVELOPER_LIBRARY_DIR)/Frameworks";
@@ -712,7 +716,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/PDKeychainBindingsControllerOSXExample.app/Contents/MacOS/PDKeychainBindingsControllerOSXExample";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -744,6 +748,7 @@
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "PDKeychainBindingsControlleriOSExample/PDKeychainBindingsControlleriOSExample-Prefix.pch";
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "PDKeychainBindingsControlleriOSExample/PDKeychainBindingsControlleriOSExample-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
@@ -758,6 +763,7 @@
 				COPY_PHASE_STRIP = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "PDKeychainBindingsControlleriOSExample/PDKeychainBindingsControlleriOSExample-Prefix.pch";
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "PDKeychainBindingsControlleriOSExample/PDKeychainBindingsControlleriOSExample-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VALIDATE_PRODUCT = YES;
@@ -776,6 +782,7 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "PDKeychainBindingsControlleriOSExampleTests/PDKeychainBindingsControlleriOSExampleTests-Prefix.pch";
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "PDKeychainBindingsControlleriOSExampleTests/PDKeychainBindingsControlleriOSExampleTests-Info.plist";
 				OTHER_LDFLAGS = (
 					"-framework",
@@ -798,6 +805,7 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "PDKeychainBindingsControlleriOSExampleTests/PDKeychainBindingsControlleriOSExampleTests-Prefix.pch";
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "PDKeychainBindingsControlleriOSExampleTests/PDKeychainBindingsControlleriOSExampleTests-Info.plist";
 				OTHER_LDFLAGS = (
 					"-framework",

--- a/PDKeychainBindingsController/PDKeychainBindings.m
+++ b/PDKeychainBindingsController/PDKeychainBindings.m
@@ -9,29 +9,11 @@
 #import "PDKeychainBindings.h"
 #import "PDKeychainBindingsController.h"
 
-
 @implementation PDKeychainBindings
-
-
 
 + (PDKeychainBindings *)sharedKeychainBindings
 {
 	return [[PDKeychainBindingsController sharedKeychainBindingsController] keychainBindings];
-}
-
-- (id)init
-{
-    self = [super init];
-    if (self) {
-        // Initialization code here.
-    }
-    
-    return self;
-}
-
-- (void)dealloc
-{
-    [super dealloc];
 }
 
 - (id)objectForKey:(NSString *)defaultName {
@@ -50,7 +32,6 @@
 - (void)removeObjectForKey:(NSString *)defaultName {
     [[PDKeychainBindingsController sharedKeychainBindingsController] setValue:nil forKeyPath:[NSString stringWithFormat:@"values.%@",defaultName]];
 }
-
 
 - (NSString *)stringForKey:(NSString *)defaultName {
     return (NSString *) [self objectForKey:defaultName];

--- a/PDKeychainBindingsController/PDKeychainBindingsController.m
+++ b/PDKeychainBindingsController/PDKeychainBindingsController.m
@@ -39,7 +39,7 @@ static PDKeychainBindingsController *sharedInstance = nil;
                            nil];
 	
     CFDataRef stringData = NULL;
-    status = SecItemCopyMatching((CFDictionaryRef)query, (CFTypeRef*)&stringData);
+    status = SecItemCopyMatching((__bridge CFDictionaryRef)query, (CFTypeRef*)&stringData);
 #else //OSX
     //SecKeychainItemRef item = NULL;
     UInt32 stringLength;
@@ -51,10 +51,10 @@ static PDKeychainBindingsController *sharedInstance = nil;
 	if(status) return nil;
 	
 #if TARGET_OS_IPHONE
-    NSString *string = [[[NSString alloc] initWithData:(id)stringData encoding:NSUTF8StringEncoding] autorelease];
+    NSString *string = [[NSString alloc] initWithData:(__bridge id)stringData encoding:NSUTF8StringEncoding];
     CFRelease(stringData);
 #else //OSX
-    NSString *string = [[[NSString alloc] initWithBytes:stringBuffer length:stringLength encoding:NSUTF8StringEncoding] autorelease];
+    NSString *string = [[NSString alloc] initWithBytes:stringBuffer length:stringLength encoding:NSUTF8StringEncoding];
     SecKeychainItemFreeAttributesAndData(NULL, stringBuffer);
 #endif
 	return string;	
@@ -65,10 +65,10 @@ static PDKeychainBindingsController *sharedInstance = nil;
 	if (!string)  {
 		//Need to delete the Key 
 #if TARGET_OS_IPHONE
-        NSDictionary *spec = [NSDictionary dictionaryWithObjectsAndKeys:(id)kSecClassGenericPassword, kSecClass,
+        NSDictionary *spec = [NSDictionary dictionaryWithObjectsAndKeys:(__bridge id)kSecClassGenericPassword, kSecClass,
                               key, kSecAttrAccount,[self serviceName], kSecAttrService, nil];
         
-        return !SecItemDelete((CFDictionaryRef)spec);
+        return !SecItemDelete((__bridge CFDictionaryRef)spec);
 #else //OSX
         SecKeychainItemRef item = NULL;
         OSStatus status = SecKeychainFindGenericPassword(NULL, (uint) [[self serviceName] lengthOfBytesUsingEncoding:NSUTF8StringEncoding], [[self serviceName] UTF8String],
@@ -81,18 +81,18 @@ static PDKeychainBindingsController *sharedInstance = nil;
     } else {
 #if TARGET_OS_IPHONE
         NSData *stringData = [string dataUsingEncoding:NSUTF8StringEncoding];
-        NSDictionary *spec = [NSDictionary dictionaryWithObjectsAndKeys:(id)kSecClassGenericPassword, kSecClass,
+        NSDictionary *spec = [NSDictionary dictionaryWithObjectsAndKeys:(__bridge id)kSecClassGenericPassword, kSecClass,
                               key, kSecAttrAccount,[self serviceName], kSecAttrService, nil];
         
         if(!string) {
-            return !SecItemDelete((CFDictionaryRef)spec);
+            return !SecItemDelete((__bridge CFDictionaryRef)spec);
         }else if([self stringForKey:key]) {
-            NSDictionary *update = [NSDictionary dictionaryWithObject:stringData forKey:(id)kSecValueData];
-            return !SecItemUpdate((CFDictionaryRef)spec, (CFDictionaryRef)update);
+            NSDictionary *update = [NSDictionary dictionaryWithObject:stringData forKey:(__bridge id)kSecValueData];
+            return !SecItemUpdate((__bridge CFDictionaryRef)spec, (__bridge CFDictionaryRef)update);
         }else{
             NSMutableDictionary *data = [NSMutableDictionary dictionaryWithDictionary:spec];
-            [data setObject:stringData forKey:(id)kSecValueData];
-            return !SecItemAdd((CFDictionaryRef)data, NULL);
+            [data setObject:stringData forKey:(__bridge id)kSecValueData];
+            return !SecItemAdd((__bridge CFDictionaryRef)data, NULL);
         }
 #else //OSX
         SecKeychainItemRef item = NULL;
@@ -150,30 +150,10 @@ static PDKeychainBindingsController *sharedInstance = nil;
     return self;
 }
 
-- (id)retain
-{
-    return self;
-}
-
-- (oneway void)release
-{
-    //do nothing
-}
-
-- (id)autorelease
-{
-    return self;
-}
-
-- (NSUInteger)retainCount
-{
-    return NSUIntegerMax;  // This is sooo not zero
-}
-
 - (id)init
 {
 	@synchronized(self) {
-		[super init];	
+		self = [super init];	
 		return self;
 	}
 }

--- a/PDKeychainBindingsControllerOSXExample/PDKeychainBindingsControllerOSXExampleAppDelegate.h
+++ b/PDKeychainBindingsControllerOSXExample/PDKeychainBindingsControllerOSXExampleAppDelegate.h
@@ -8,18 +8,12 @@
 
 #import <Cocoa/Cocoa.h>
 
-@interface PDKeychainBindingsControllerOSXExampleAppDelegate : NSObject <NSApplicationDelegate> {
-@private
-    NSWindow *window;
-    NSTextField *RevealLabel;
-    NSSecureTextField *passwordField;
-    NSButton *RevealConcealButton;
-}
+@interface PDKeychainBindingsControllerOSXExampleAppDelegate : NSObject <NSApplicationDelegate>
 
-@property (assign) IBOutlet NSWindow *window;
-@property (assign) IBOutlet NSTextField *RevealLabel;
-@property (assign) IBOutlet NSSecureTextField *passwordField;
-@property (assign) IBOutlet NSButton *RevealConcealButton;
+@property (strong) IBOutlet NSWindow *window;
+@property (strong) IBOutlet NSTextField *RevealLabel;
+@property (strong) IBOutlet NSSecureTextField *passwordField;
+@property (strong) IBOutlet NSButton *RevealConcealButton;
 - (IBAction)toggleRevealConceal:(id)sender;
 
 @end

--- a/PDKeychainBindingsControllerOSXExampleTests/PDKeychainBindingsControllerTest.m
+++ b/PDKeychainBindingsControllerOSXExampleTests/PDKeychainBindingsControllerTest.m
@@ -15,9 +15,9 @@
 - (NSString*) stringWithUUID {
     CFUUIDRef	uuidObj = CFUUIDCreate(nil);//create a new UUID
     //get the string representation of the UUID
-    NSString	*uuidString = (NSString*)CFUUIDCreateString(nil, uuidObj);
+    NSString	*uuidString = (__bridge_transfer NSString*)CFUUIDCreateString(nil, uuidObj);
     CFRelease(uuidObj);
-    return [uuidString autorelease];
+    return uuidString;
 }
 
 - (void)setUp

--- a/PDKeychainBindingsControllerOSXExampleTests/PDKeychainBindingsTest.m
+++ b/PDKeychainBindingsControllerOSXExampleTests/PDKeychainBindingsTest.m
@@ -15,9 +15,9 @@
 - (NSString*) stringWithUUID {
     CFUUIDRef	uuidObj = CFUUIDCreate(nil);//create a new UUID
     //get the string representation of the UUID
-    NSString	*uuidString = (NSString*)CFUUIDCreateString(nil, uuidObj);
+    NSString	*uuidString = (__bridge_transfer NSString*)CFUUIDCreateString(nil, uuidObj);
     CFRelease(uuidObj);
-    return [uuidString autorelease];
+    return uuidString;
 }
 
 - (void)setUp
@@ -79,7 +79,7 @@
         NSLog(@"Error copying Keychain item: %@",errorMsg);
         CFRelease(errorMsg);
     }
-    NSString *string = [[[NSString alloc] initWithBytes:stringBuffer length:stringLength encoding:NSUTF8StringEncoding] autorelease];
+    NSString *string = [[NSString alloc] initWithBytes:stringBuffer length:stringLength encoding:NSUTF8StringEncoding];
     STAssertEqualObjects(string, targetString, @"retrieved string from keychain '%@' not equal to expected 'foo'", string);
     SecKeychainItemFreeAttributesAndData(NULL, stringBuffer);
     

--- a/PDKeychainBindingsControllerOSXExampleTests/TestContainerClass.h
+++ b/PDKeychainBindingsControllerOSXExampleTests/TestContainerClass.h
@@ -8,11 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
+@interface TestContainerClass : NSObject
 
-@interface TestContainerClass : NSObject {
-@private
-    NSString *value;
-}
-
-@property (assign) NSString *value;
+@property (strong) NSString *value;
 @end

--- a/PDKeychainBindingsControllerOSXExampleTests/TestContainerClass.m
+++ b/PDKeychainBindingsControllerOSXExampleTests/TestContainerClass.m
@@ -8,24 +8,8 @@
 
 #import "TestContainerClass.h"
 
-
 @implementation TestContainerClass
 
 @synthesize value;
-
-- (id)init
-{
-    self = [super init];
-    if (self) {
-        // Initialization code here.
-    }
-    
-    return self;
-}
-
-- (void)dealloc
-{
-    [super dealloc];
-}
 
 @end

--- a/PDKeychainBindingsControlleriOSExample/PDKeychainBindingsControlleriOSExampleAppDelegate.h
+++ b/PDKeychainBindingsControlleriOSExample/PDKeychainBindingsControlleriOSExampleAppDelegate.h
@@ -10,12 +10,10 @@
 
 @class PDKeychainBindingsControlleriOSExampleViewController;
 
-@interface PDKeychainBindingsControlleriOSExampleAppDelegate : NSObject <UIApplicationDelegate> {
+@interface PDKeychainBindingsControlleriOSExampleAppDelegate : NSObject <UIApplicationDelegate>
 
-}
+@property (nonatomic) IBOutlet UIWindow *window;
 
-@property (nonatomic, retain) IBOutlet UIWindow *window;
-
-@property (nonatomic, retain) IBOutlet PDKeychainBindingsControlleriOSExampleViewController *viewController;
+@property (nonatomic) IBOutlet PDKeychainBindingsControlleriOSExampleViewController *viewController;
 
 @end

--- a/PDKeychainBindingsControlleriOSExample/PDKeychainBindingsControlleriOSExampleAppDelegate.m
+++ b/PDKeychainBindingsControlleriOSExample/PDKeychainBindingsControlleriOSExampleAppDelegate.m
@@ -65,11 +65,4 @@
      */
 }
 
-- (void)dealloc
-{
-    [_window release];
-    [_viewController release];
-    [super dealloc];
-}
-
 @end

--- a/PDKeychainBindingsControlleriOSExample/PDKeychainBindingsControlleriOSExampleViewController.h
+++ b/PDKeychainBindingsControlleriOSExample/PDKeychainBindingsControlleriOSExampleViewController.h
@@ -8,15 +8,11 @@
 
 #import <UIKit/UIKit.h>
 
-@interface PDKeychainBindingsControlleriOSExampleViewController : UIViewController <UITextFieldDelegate>{
-    
-    UITextField *passwordField;
-    UIButton *revealButton;
-    UILabel *retrievedLabel;
-}
-@property (nonatomic, retain) IBOutlet UITextField *passwordField;
-@property (nonatomic, retain) IBOutlet UIButton *revealButton;
-@property (nonatomic, retain) IBOutlet UILabel *retrievedLabel;
+@interface PDKeychainBindingsControlleriOSExampleViewController : UIViewController <UITextFieldDelegate>
+
+@property (nonatomic) IBOutlet UITextField *passwordField;
+@property (nonatomic) IBOutlet UIButton *revealButton;
+@property (nonatomic) IBOutlet UILabel *retrievedLabel;
 
 - (IBAction)toggleReveal:(id)sender;
 

--- a/PDKeychainBindingsControlleriOSExample/PDKeychainBindingsControlleriOSExampleViewController.m
+++ b/PDKeychainBindingsControlleriOSExample/PDKeychainBindingsControlleriOSExampleViewController.m
@@ -14,13 +14,6 @@
 @synthesize passwordField;
 @synthesize revealButton;
 
-- (void)dealloc
-{
-    [passwordField release];
-    [revealButton release];
-    [retrievedLabel release];
-    [super dealloc];
-}
 
 - (void)didReceiveMemoryWarning
 {
@@ -43,11 +36,8 @@
 
 - (void)viewDidUnload
 {
-    [passwordField release];
     passwordField = nil;
-    [revealButton release];
     revealButton = nil;
-    [retrievedLabel release];
     retrievedLabel = nil;
     [super viewDidUnload];
     // Release any retained subviews of the main view.

--- a/PDKeychainBindingsControlleriOSExample/main.m
+++ b/PDKeychainBindingsControlleriOSExample/main.m
@@ -10,8 +10,8 @@
 
 int main(int argc, char *argv[])
 {
-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-    int retVal = UIApplicationMain(argc, argv, nil, nil);
-    [pool release];
-    return retVal;
+    @autoreleasepool {
+        int retVal = UIApplicationMain(argc, argv, nil, nil);
+        return retVal;
+    }
 }

--- a/PDKeychainBindingsControlleriOSExampleTests/PDKeychainBindingsTest.m
+++ b/PDKeychainBindingsControlleriOSExampleTests/PDKeychainBindingsTest.m
@@ -15,9 +15,9 @@
 - (NSString*) stringWithUUID {
     CFUUIDRef	uuidObj = CFUUIDCreate(nil);//create a new UUID
     //get the string representation of the UUID
-    NSString	*uuidString = (NSString*)CFUUIDCreateString(nil, uuidObj);
+    NSString	*uuidString = (__bridge_transfer NSString*)CFUUIDCreateString(nil, uuidObj);
     CFRelease(uuidObj);
-    return [uuidString autorelease];
+    return uuidString;
 }
 
 #if USE_APPLICATION_UNIT_TEST     // all code under test is in the iPhone Application
@@ -60,11 +60,11 @@
                            nil];
 	
     CFDataRef stringData = NULL;
-    OSStatus status = SecItemCopyMatching((CFDictionaryRef)query, (CFTypeRef*)&stringData);
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, (CFTypeRef*)&stringData);
     
     STAssertEquals((uint) 0, (uint) status, @"Failed to retrive data, status was '%i'", status);
     
-    NSString *string = [[[NSString alloc] initWithData:(id)stringData encoding:NSUTF8StringEncoding] autorelease];
+    NSString *string = [[NSString alloc] initWithData:(__bridge id)stringData encoding:NSUTF8StringEncoding];
     STAssertEqualObjects(string, targetString, @"retrieved string from keychain '%@' not equal to expected 'foo'", string);
     CFRelease(stringData);
     


### PR DESCRIPTION
Converted both targets (iOS and OS X) to Automatic Reference Counting.

Also, I cleaned some properties-related code, according to Apple latest guidelines (see WWDC 2012 “Session 413 - Migrating to Modern Objective-C”).
