### PR TITLE
Avoid unused variable warning.

### DIFF
--- a/PDKeychainBindingsController/PDKeychainBindingsController.m
+++ b/PDKeychainBindingsController/PDKeychainBindingsController.m
@@ -126,7 +126,7 @@ static PDKeychainBindingsController *sharedInstance = nil;
 {
 	@synchronized (self) {
 		if (sharedInstance == nil) {
-			[[self alloc] init]; // assignment not done here, see allocWithZone
+			__unused id unused = [[self alloc] init]; // assignment not done here, see allocWithZone
 		}
 	}
 	


### PR DESCRIPTION
Here's a fix to suppress the warning. I'll look at updating the singleton on master.
